### PR TITLE
sc-gyro-plot.py: fix size mismatch

### DIFF
--- a/scripts/sc-gyro-plot.py
+++ b/scripts/sc-gyro-plot.py
@@ -102,7 +102,12 @@ def _main():
 
         for name in imu.keys():
             imu[name].append(sci._asdict()[name])
-            imu[name] = imu[name][-len(times):]
+            nt = len(times)
+            ni = len(imu[name])
+            if nt < ni:
+                imu[name] = imu[name][-nt:]
+            elif nt > ni:
+                times = times[nt-ni:]
             curves[name].setData(times, imu[name])
 
     app.processEvents()


### PR DESCRIPTION
Running `sc-gyro-plot.py` fails after less than a second:

```txt
Exception in thread Thread-19:
Traceback (most recent call last):
  File "/usr/lib/python3.5/threading.py", line 914, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.5/threading.py", line 1180, in run
    self.function(*self.args, **self.kwargs)
  File "/usr/lib/python3.5/site-packages/steamcontroller/__init__.py", line 260, in _callbackTimer
    self._cb(self, self._tup)
  File "./scripts/sc-gyro-plot.py", line 106, in update
    curves[name].setData(times, imu[name])
  File "/usr/lib/python3.5/site-packages/pyqtgraph/graphicsItems/PlotDataItem.py", line 460, in setData
    self.updateItems()
  File "/usr/lib/python3.5/site-packages/pyqtgraph/graphicsItems/PlotDataItem.py", line 486, in updateItems
    self.curve.setData(x=x, y=y, **curveArgs)
  File "/usr/lib/python3.5/site-packages/pyqtgraph/graphicsItems/PlotCurveItem.py", line 299, in setData
    self.updateData(*args, **kargs)
  File "/usr/lib/python3.5/site-packages/pyqtgraph/graphicsItems/PlotCurveItem.py", line 345, in updateData
    raise Exception("X and Y arrays must be the same shape--got %s and %s." % (self.xData.shape, self.yData.shape))
Exception: X and Y arrays must be the same shape--got (20,) and (19,).
```

The issue is that `times` and `imu[name]` do not necessarily have the same size, as sometimes `len(times) > len(imu[name])`. This PR is an attempt to solve that problem. One question remains though: should we discard the beginning (as I did) or the end of `times` when this happens?