### PR TITLE
Change device version of emulated x360 controller

### DIFF
--- a/src/uinput.c
+++ b/src/uinput.c
@@ -44,6 +44,7 @@ int uinput_init(
     int     keyboard,
     __u16   vendor,
     __u16   product,
+	__u16   version,
     char *  name)
 {
     struct uinput_user_dev uidev;
@@ -60,7 +61,7 @@ int uinput_init(
     uidev.id.bustype = BUS_USB;
     uidev.id.vendor = vendor;
     uidev.id.product = product;
-    uidev.id.version = 1;
+    uidev.id.version = version;
 
     /* Key Event initialisation */
     if (key_len > 0 && ioctl(fd, UI_SET_EVBIT, EV_KEY) < 0) {

--- a/src/uinput.py
+++ b/src/uinput.py
@@ -184,7 +184,7 @@ class UInput(object):
     """
 
 
-    def __init__(self, vendor, product, name, keys, axes, rels, keyboard=False):
+    def __init__(self, vendor, product, version, name, keys, axes, rels, keyboard=False):
         self._lib = None
         self._k = keys
         if not axes or len(axes) == 0:
@@ -196,6 +196,7 @@ class UInput(object):
         self.vendor = vendor
         self.product = product
         self.name = name
+        self.version = version
         self.keyboard = keyboard
         self._fd = None
 
@@ -235,6 +236,7 @@ class UInput(object):
         c_r        = (ctypes.c_uint16 * len(self._r))(*self._r)
         c_vendor   = ctypes.c_uint16(self.vendor)
         c_product  = ctypes.c_uint16(self.product)
+        c_version  = ctypes.c_uint16(self.version)
         c_keyboard = ctypes.c_int(self.keyboard)
 
         c_name = ctypes.c_char_p(self.name)
@@ -251,6 +253,7 @@ class UInput(object):
                                          c_keyboard,
                                          c_vendor,
                                          c_product,
+                                         c_version,
                                          c_name)
 
 
@@ -366,6 +369,7 @@ class Gamepad(UInput):
     def __init__(self):
         super(Gamepad, self).__init__(vendor=0x045e,
                                       product=0x028e,
+                                      version=1,
                                       name=b"Microsoft X-Box 360 pad",
                                       keys=[Keys.BTN_START,
                                             Keys.BTN_MODE,
@@ -413,6 +417,7 @@ class Mouse(UInput):
     def __init__(self):
         super(Mouse, self).__init__(vendor=0x28de,
                                     product=0x1142,
+                                    version=1,
                                     name=b"Steam Controller Mouse",
                                     keys=[Keys.BTN_LEFT,
                                           Keys.BTN_RIGHT,
@@ -692,6 +697,7 @@ class Keyboard(UInput):
     def __init__(self):
         super(Keyboard, self).__init__(vendor=0x28de,
                                        product=0x1142,
+                                       version=1,
                                        name=b"Steam Controller Keyboard",
                                        keys=Scans.keys(),
                                        axes=[],

--- a/src/uinput.py
+++ b/src/uinput.py
@@ -369,7 +369,7 @@ class Gamepad(UInput):
     def __init__(self):
         super(Gamepad, self).__init__(vendor=0x045e,
                                       product=0x028e,
-                                      version=1,
+                                      version=0x110,
                                       name=b"Microsoft X-Box 360 pad",
                                       keys=[Keys.BTN_START,
                                             Keys.BTN_MODE,


### PR DESCRIPTION
Hello,

I had bug report that affects your driver as well:

Emulated x360 controller reports version 0x1, which is apparently not in SDL's gamecontrollerdb.txt and thus makes some games (at least HL2) to ignore it. You can check it simply by starting HL2 and enabling gamepad (either in ui or by `exec 360controller` in console). If version is changed to 0x110, GUID reported by SDL is changed to 030000005e0400008e020000**1001**0000 and HL2 responds to inputs.

kozec/sc-controller#139 has better description.

This PR turns *uidev.id.version* in uinput.c to argument and makes that argument visible back in UInput class in python. Then it adds default values for all three supported device types.