### PR TITLE
Fix #28: better deadzone and overlap for diagonals

### DIFF
--- a/scripts/sc-xbox.py
+++ b/scripts/sc-xbox.py
@@ -42,8 +42,9 @@ def evminit():
 
     evm.setStickAxes(Axes.ABS_X, Axes.ABS_Y)
     evm.setPadAxes(Pos.RIGHT, Axes.ABS_RX, Axes.ABS_RY)
-    evm.setPadAxesAsButtons(Pos.LEFT, [Axes.ABS_HAT0X,
-                                       Axes.ABS_HAT0Y])
+    evm.setPadAxesAsButtons(Pos.LEFT,
+                            [Axes.ABS_HAT0X, Axes.ABS_HAT0Y],
+                            deadzone=0.3)
 
     evm.setTrigAxis(Pos.LEFT, Axes.ABS_Z)
     evm.setTrigAxis(Pos.RIGHT, Axes.ABS_RZ)


### PR DESCRIPTION
First of all I've changed the code to correct for the weird rotational offset on the d-touch-pad. Your code was aware of that issue but only for the case where `len(self._pad_evts[pos]) == 4`. I also tweaked the default d-pad deadzone in the x-box script. It feels snappy and god to use, please give it a try. I also decided to allow multiple buttons to be pressed (i.e. diagonals) for the case where `len(self._pad_evts[pos]) == 4`.

EDIT: Also worth to mention, I changed the angle concept to just use the plain distance to the axes. This might be debatable, but especially for the d-pad that makes perfect sense. It means "as soon as you leave the grooves indicating straight directions, you input a diagonal".

I hope you find the time to test this out and merge it.