### PR TITLE
Keep alive daemon

### DIFF
--- a/scripts/sc-xbox.py
+++ b/scripts/sc-xbox.py
@@ -42,8 +42,9 @@ def evminit():
 
     evm.setStickAxes(Axes.ABS_X, Axes.ABS_Y)
     evm.setPadAxes(Pos.RIGHT, Axes.ABS_RX, Axes.ABS_RY)
-    evm.setPadAxesAsButtons(Pos.LEFT, [Axes.ABS_HAT0X,
-                                       Axes.ABS_HAT0Y])
+    evm.setPadAxesAsButtons(Pos.LEFT,
+                            [Axes.ABS_HAT0X, Axes.ABS_HAT0Y],
+                            deadzone=0.3)
 
     evm.setTrigAxis(Pos.LEFT, Axes.ABS_Z)
     evm.setTrigAxis(Pos.RIGHT, Axes.ABS_RZ)


### PR DESCRIPTION
Adding an option to `SteamController.run` to keep the daemon alive when the gamepad gets disconnected. Daemon will try to reconnect by polling every 2 seconds. This could be optimized by using the hotplug api (http://libusb.sourceforge.net/api-1.0/libusb_hotplug.html).